### PR TITLE
Use env to find bash.

### DIFF
--- a/bin/servant
+++ b/bin/servant
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -n "$INSIDE_EMACS" ]]; then
   SERVANT_EMACS="emacs"


### PR DESCRIPTION
This helps on systems without /bin/bash, like e.g. NetBSD.